### PR TITLE
Install Python packages with OS not pip.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -84,10 +84,10 @@
       become: true
 
     - name: Ensure required Python libraries are installed.
-      ansible.builtin.pip:
+      ansible.builtin.package:
         name:
-          - openshift
-          - pyyaml
+          - python3-openshift
+          - python3-yaml
         state: present
       become: true
 


### PR DESCRIPTION
Raspberry Pi OS bookworm warns:

> {"changed": false, "cmd": ["/usr/bin/python3", "-m", "pip.__main__", "install", "openshift", "pyyaml"], "msg": "\n:stderr: error: externally-managed-environment\n\n× This environment is externally managed\n╰─> To install Python packages system-wide, try apt install\n    python3-xyz, where xyz is the package you are trying to\n    install.\n    \n    If you wish to install a non-Debian-packaged Python package,\n    create a virtual environment using python3 -m venv path/to/venv.\n    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make\n    sure you have python3-full installed.\n    \n    For more information visit http://rptl.io/venv\n\nnote: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.\nhint: See PEP 668 for the detailed specification.\n"}

It might be a cleaner solution to create a venv in Python but I'm not familiar with Ansible nor do I know where these are used downstream so I've chosen to install them as OS packages here for simplicity. 