### PR TITLE
Update the location of `cmdline.txt`.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -19,7 +19,7 @@
   tasks:
     - name: Ensure cgroups are configured correctly in cmdline.txt.
       ansible.builtin.replace:
-        path: /boot/cmdline.txt
+        path: /boot/firmware/cmdline.txt
         regexp: '^([\w](?!.*\b{{ item }}\b).*)$'
         replace: '\1 {{ item }}'
       with_items:


### PR DESCRIPTION
In more recent versions of RaspiOS based on Debian 12.5 Bookworm, the location of `cmdline.txt` has changed: the original file still exists, but with a warning not to edit it, and directing the user to the new location.