### PR TITLE
Switch boot options location based on distro.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set up cluster-wide configuration.
   hosts: cluster
-  gather_facts: false
+  gather_facts: true
   become: true
 
   handlers:
@@ -26,6 +26,18 @@
         - "cgroup_memory=1"
         - "cgroup_enable=memory"
       notify: reboot-pi
+      when: ansible_distribution == 'Debian'
+
+    - name: Ensure cgroups are configured correctly in ubuntuEnv.txt.
+      ansible.builtin.replace:
+        path: /boot/firmware/ubuntuEnv.txt
+        regexp: '^(bootargs=[\w](?!.*\b{{ item }}\b).*)$'
+        replace: '\1 {{ item }}'
+      with_items:
+        - "cgroup_memory=1"
+        - "cgroup_enable=memory"
+      notify: reboot-pi
+      when: ansible_distribution == 'Ubuntu'
 
     - name: Download K3s install script.
       ansible.builtin.get_url:


### PR DESCRIPTION
In RaspiOS the boot options are specified in  `/boot/firmware/cmdline.txt`, but in the TPi-provided Ubuntu image for the RK1 they're in `/boot/firmware/ubuntuEnv.txt`.

There are various ways this could be done, but this is probably the simplest. We could also split this out into a distro-specific file and also set `ansible_user` there; at the moment I'm handling this in `hosts.ini` and `group_vars`.