### PR TITLE
Simplify iozone call and also measure sequential reads

### DIFF
--- a/benchmarks/disk-benchmark.sh
+++ b/benchmarks/disk-benchmark.sh
@@ -99,12 +99,8 @@ printf "\n"
 #   --eta-newline=1
 # printf "\n"
 
-printf "Running iozone 1024K random read and write tests...\n"
-./iozone -e -I -a -s 100M -r 1024k -i 0 -i 2 -f $DEVICE_MOUNT_PATH/iozone
-printf "\n"
-
-printf "Running iozone 4K random read and write tests...\n"
-./iozone -e -I -a -s 100M -r 4k -i 0 -i 2 -f $DEVICE_MOUNT_PATH/iozone
+printf "Running iozone 4K / 1024K read and write tests...\n"
+./iozone -e -I -a -s 100M -r 4k -r 1024k -i 0 -i 1 -i 2 -f $DEVICE_MOUNT_PATH/iozone | cut -c7-78 | tail -n6 | head -n4
 printf "\n"
 
 printf "Disk benchmark complete!\n\n"


### PR DESCRIPTION
Execution time slightly increases but this will allow in the future to get a bigger picture about the difference the fio measurement with 4 concurrent jobs (quite unrealistic for anything anyone will be doing ever on an SBC) and one single job makes especially in situations where cpufreq governors are used that will quickly ramp up CPU clockspeeds with 4 jobs in parallel but remain on low clockspeeds with iozone (and real-world workloads).

The ` | cut -c7-78 | tail -n6 | head -n4` can be deleted if the whole iozone output is wanted and not just the results in proper Markdown format.